### PR TITLE
fix comments in portainer-demo.sh, add exec_in

### DIFF
--- a/portainer-demo.sh
+++ b/portainer-demo.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/bin/sh
+
+exec_in() { docker-compose exec -T $@; }
 
 # Fresh start
 docker-compose down
@@ -7,18 +9,18 @@ docker-compose down
 docker-compose up -d manager1 manager2 worker1 worker2
 
 # Manager1 init
-docker-compose exec manager1 docker swarm init
-TOKEN_WORKER="$(docker-compose exec manager1 docker swarm join-token -q worker)"
-TOKEN_MANAGER=`docker-compose exec manager1 docker swarm join-token manager | grep 'token' | xargs | sed -e 's/--token //'`
+exec_in manager1 docker swarm init
+TOKEN_WORKER="$(exec_in manager1 docker swarm join-token -q worker)"
+TOKEN_MANAGER="$(exec_in manager1 docker swarm join-token -q manager)"
 
-Manager2 join
-docker-compose exec manager2 docker swarm join --token $TOKEN_MANAGER manager1:2377
+# Manager2 join
+exec_in manager2 docker swarm join --token $TOKEN_MANAGER manager1:2377
 
-Worker1 join
-docker-compose exec worker1 docker swarm join --token $TOKEN_WORKER manager1:2377
+# Worker1 join
+exec_in worker1 docker swarm join --token $TOKEN_WORKER manager1:2377
 
 # Worker2 join
-docker-compose exec worker2 docker swarm join --token $TOKEN_WORKER manager1:2377
+exec_in worker2 docker swarm join --token $TOKEN_WORKER manager1:2377
 
 # Up portainer
 docker-compose up -d proxy templates portainer


### PR DESCRIPTION
This PR modifies `portainer-demo.sh`:
- `#!/bin/bash` ir changed to `#!/bin/sh`, in order to allow the execution in environments without bash (such as alpine).
- Lines `Manager2 join` and `Worker1 join` are fixed (the `#` was missing).
- Instead of using `grep`, `xargs` and `sed`, the manager join-token is retrieved with `-q`, as it is done for the worker join-token.
- `exec_in() { docker-compose exec -T $@; }` is defined to reduce verbosity and to make it easier to see which commands are executed inside each container.

The modifications above make this repo suitable to be launched automatically in a play-with-docker playground: http://play-with-docker.com/?stack=https://gist.githubusercontent.com/1138-4EB/85eaafe0129bb3a5ad7117a65de47bbc/raw/docker-compose.yml Furthermore, the [gist](https://gist.githubusercontent.com/1138-4EB/85eaafe0129bb3a5ad7117a65de47bbc/raw/docker-compose.yml) can be added to this repo (maybe to subdir `play-with-docker`), in order to keep all the content together.

Running the Portainer demo in play-with-docker provides these advantages:

- Compared to *the public demo cluster [which] is reset every 15min*, sessions in play-with-docker last 4 hours.
- Every user spins its own demo, so there is no shared usage of the demo.


